### PR TITLE
Focus Left/Right hotkey override behavior

### DIFF
--- a/src/layouts/threecolumnlayout.ts
+++ b/src/layouts/threecolumnlayout.ts
@@ -203,20 +203,20 @@ class ThreeColumnLayout implements ILayout {
       case Shortcut.Decrease:
         this.resizeMaster(ctx, -1);
         return true;
-        // case Shortcut.FocusLeft:
-        //   this.masterRatio = clip(
-        //     slide(this.masterRatio, -0.05),
-        //     ThreeColumnLayout.MIN_MASTER_RATIO,
-        //     ThreeColumnLayout.MAX_MASTER_RATIO
-        //   );
-        //   return true;
-        // case Shortcut.FocusRight:
-        //   this.masterRatio = clip(
-        //     slide(this.masterRatio, +0.05),
-        //     ThreeColumnLayout.MIN_MASTER_RATIO,
-        //     ThreeColumnLayout.MAX_MASTER_RATIO
-        //   );
-        return true;
+      // case Shortcut.FocusLeft:
+      //   this.masterRatio = clip(
+      //     slide(this.masterRatio, -0.05),
+      //     ThreeColumnLayout.MIN_MASTER_RATIO,
+      //     ThreeColumnLayout.MAX_MASTER_RATIO
+      //   );
+      //   return true;
+      // case Shortcut.FocusRight:
+      //   this.masterRatio = clip(
+      //     slide(this.masterRatio, +0.05),
+      //     ThreeColumnLayout.MIN_MASTER_RATIO,
+      //     ThreeColumnLayout.MAX_MASTER_RATIO
+      //   );
+      // return true;
       default:
         return false;
     }

--- a/src/layouts/threecolumnlayout.ts
+++ b/src/layouts/threecolumnlayout.ts
@@ -203,19 +203,19 @@ class ThreeColumnLayout implements ILayout {
       case Shortcut.Decrease:
         this.resizeMaster(ctx, -1);
         return true;
-      case Shortcut.FocusLeft:
-        this.masterRatio = clip(
-          slide(this.masterRatio, -0.05),
-          ThreeColumnLayout.MIN_MASTER_RATIO,
-          ThreeColumnLayout.MAX_MASTER_RATIO
-        );
-        return true;
-      case Shortcut.FocusRight:
-        this.masterRatio = clip(
-          slide(this.masterRatio, +0.05),
-          ThreeColumnLayout.MIN_MASTER_RATIO,
-          ThreeColumnLayout.MAX_MASTER_RATIO
-        );
+        // case Shortcut.FocusLeft:
+        //   this.masterRatio = clip(
+        //     slide(this.masterRatio, -0.05),
+        //     ThreeColumnLayout.MIN_MASTER_RATIO,
+        //     ThreeColumnLayout.MAX_MASTER_RATIO
+        //   );
+        //   return true;
+        // case Shortcut.FocusRight:
+        //   this.masterRatio = clip(
+        //     slide(this.masterRatio, +0.05),
+        //     ThreeColumnLayout.MIN_MASTER_RATIO,
+        //     ThreeColumnLayout.MAX_MASTER_RATIO
+        //   );
         return true;
       default:
         return false;

--- a/src/layouts/tilelayout.ts
+++ b/src/layouts/tilelayout.ts
@@ -61,7 +61,7 @@ class TileLayout implements ILayout {
     masterPart.gap =
       masterPart.primary.inner.gap =
       masterPart.secondary.gap =
-        CONFIG.tileLayoutGap;
+      CONFIG.tileLayoutGap;
   }
 
   public adjust(
@@ -90,20 +90,20 @@ class TileLayout implements ILayout {
 
   public handleShortcut(ctx: EngineContext, input: Shortcut) {
     switch (input) {
-      case Shortcut.FocusLeft:
-        this.masterRatio = clip(
-          slide(this.masterRatio, -0.05),
-          TileLayout.MIN_MASTER_RATIO,
-          TileLayout.MAX_MASTER_RATIO
-        );
-        break;
-      case Shortcut.FocusRight:
-        this.masterRatio = clip(
-          slide(this.masterRatio, +0.05),
-          TileLayout.MIN_MASTER_RATIO,
-          TileLayout.MAX_MASTER_RATIO
-        );
-        break;
+      // case Shortcut.FocusLeft:
+      //   this.masterRatio = clip(
+      //     slide(this.masterRatio, -0.05),
+      //     TileLayout.MIN_MASTER_RATIO,
+      //     TileLayout.MAX_MASTER_RATIO
+      //   );
+      //   break;
+      // case Shortcut.FocusRight:
+      //   this.masterRatio = clip(
+      //     slide(this.masterRatio, +0.05),
+      //     TileLayout.MIN_MASTER_RATIO,
+      //     TileLayout.MAX_MASTER_RATIO
+      //   );
+      //   break;
       case Shortcut.Increase:
         // TODO: define arbitrary constant
         if (this.numMaster < 10) this.numMaster += 1;


### PR DESCRIPTION
Hey, huge thanks to you for picking this project up.  Thought my beloved krohnkite/bismuth may be dead till I found your fork.

I updated from the original Krohnkite repository to yours and noticed that the "Focus Left" and "Focus Right" hotkeys were acting like the "Grow/Shrink Width" hotkeys rather than modifying which tile was being focused on. 

I don't know much about Typescript, I'm more of an embedded guy who enjoys the Krohnkite + KDE environment as a user. Despite that, I just did some basic searching through the repo and came across these FocusLeft and FocusRight layout specific shortcut handler cases. 

I'm assuming the intended behavior is that in three-tile mode, the focused window will gain more real estate when focused upon. It appears based on my testing that the commented out definitions are completely overriding the Focus Left and Focus Right hotkeys rather than adding this behavior to them. I commented these out and then recompiled, and found the hotkeys to work as originally expected. 

I'm not familiar enough with the libraries/structures to figure out how to implement the focus left/right in ADDITION to the growth behavior if that was the intended goal. But wanted to call attention and offer a fix in this PR.
