### PR TITLE
Implemented Stacked layout for vertical/portrait-mode monitors.

### DIFF
--- a/res/config.ui
+++ b/res/config.ui
@@ -152,6 +152,16 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="kcfg_enableStackedLayout">
+            <property name="toolTip">
+             <string>Enable Stacked layout</string>
+            </property>
+            <property name="text">
+             <string>Stacked Layout</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="kcfg_enableSpreadLayout">
             <property name="toolTip">
              <string>Enable Spread layout</string>

--- a/res/config.xml
+++ b/res/config.xml
@@ -51,6 +51,11 @@
         <default>false</default>
     </entry>
 
+    <entry name="enableStackedLayout" type="Bool">
+	    <label>Enable/disable Stacked layout</label>
+        <default>false</default>
+    </entry>
+
     <entry name="enableFloatingLayout" type="Bool">
 	    <label>Enable/disable Floating layout</label>
         <default>false</default>

--- a/res/shortcuts.qml
+++ b/res/shortcuts.qml
@@ -305,4 +305,14 @@ Item {
         text: "Krohnkite: Quarter Layout";
         sequence: "";
     }
+    function getStackedLayout() {
+        return stackedLayout;
+    }
+    ShortcutHandler {
+        id: stackedLayout;
+
+        name: "KrohnkiteStackedLayout";
+        text: "Krohnkite: Stacked Layout";
+        sequence: "";
+    }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -105,6 +105,7 @@ interface IShortcuts {
   getStairLayout(): ShortcutHandler;
   getFloatingLayout(): ShortcutHandler;
   getQuarterLayout(): ShortcutHandler;
+  getStackedLayout(): ShortcutHandler;
 }
 
 //#region Driver

--- a/src/driver/kwin/kwinconfig.ts
+++ b/src/driver/kwin/kwinconfig.ts
@@ -88,6 +88,7 @@ class KWinConfig implements IConfig {
         ["enableStairLayout", true, StairLayout],
         ["enableSpiralLayout", true, SpiralLayout],
         ["enableQuarterLayout", false, QuarterLayout],
+        ["enableStackedLayout", false, StackedLayout],
         ["enableFloatingLayout", false, FloatingLayout],
         ["enableCascadeLayout", false, CascadeLayout], // TODO: add config
       ] as Array<[string, boolean, ILayoutClass]>

--- a/src/driver/kwin/kwindriver.ts
+++ b/src/driver/kwin/kwindriver.ts
@@ -261,6 +261,9 @@ class KWinDriver implements IDriverContext {
     this.shortcuts
       .getQuarterLayout()
       .activated.connect(callbackShortcutLayout(QuarterLayout));
+    this.shortcuts
+      .getStackedLayout()
+      .activated.connect(callbackShortcutLayout(StackedLayout));
   }
 
   //#region Helper functions

--- a/src/layouts/stackedlayout.ts
+++ b/src/layouts/stackedlayout.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2024 Jas Singh <singh.jaskir@outlook.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+class StackedLayout implements ILayout {
+  public static readonly id = "StackedLayout";
+
+  public readonly classID = StackedLayout.id;
+
+  public get description(): string {
+    return "Stacked";
+  }
+
+  private parts: RotateLayoutPart<
+    HalfSplitLayoutPart<StackLayoutPart, StackLayoutPart>
+  >;
+
+  constructor() {
+    this.parts = new RotateLayoutPart(
+      new HalfSplitLayoutPart(
+        new StackLayoutPart(),
+        new StackLayoutPart()
+      )
+    );
+
+    const masterPart = this.parts.inner;
+    masterPart.gap =
+      masterPart.secondary.gap =
+      CONFIG.tileLayoutGap;
+  }
+
+  public adjust(
+    area: Rect,
+    tiles: WindowClass[],
+    basis: WindowClass,
+    delta: RectDelta
+  ) {
+    this.parts.adjust(area, tiles, basis, delta);
+  }
+
+  public apply(ctx: EngineContext, tileables: WindowClass[], area: Rect): void {
+    tileables.forEach((tileable) => (tileable.state = WindowState.Tiled));
+
+    if (tileables.length > 1) {
+      this.parts.inner.angle = 90;
+    }
+
+    this.parts.apply(area, tileables).forEach((geometry, i) => {
+      tileables[i].geometry = geometry;
+    });
+  }
+
+  public clone(): ILayout {
+    const other = new StackedLayout();
+    return other;
+  }
+
+  public handleShortcut(ctx: EngineContext, input: Shortcut) {
+    switch (input) {
+      case Shortcut.Rotate:
+        this.parts.rotate(90);
+        break;
+      default:
+        return false;
+    }
+    return true;
+  }
+
+  public toString(): string {
+    return (
+      "StackedLayout()"
+    );
+  }
+}


### PR DESCRIPTION
Added a layout that adds tiles in a stacked manner... each new tile is added towards the bottom. The section is split in half where the primary tile (master tile) sits at the top half and the remaining tiles sit in the bottom half. The master tile can be assigned via the Krohnkite keybind.

Here is a video demonstration. Ignore the weird glitchy behavior, this is the result of Wayland being terrible with screen captures.
<video src='https://github.com/anametologin/krohnkite/assets/21210205/7da9c0bc-d190-4591-bb12-f791790a40c5' width=180/>
