### PR TITLE
make: ensure version in package.json is updated every time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,4 +82,4 @@ $(NODE_SCRIPT): $(SRC)
 package_json: package.json
 	sed -i 's/"version": [^,]*/"version": "$(PROJECT_VER)"/' package.json
 
-.PHONY: all clean install package test run stop
+.PHONY: all clean install package test run stop package_json

--- a/package.json
+++ b/package.json
@@ -6,10 +6,9 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {},
   "devDependencies": {
-    "typescript": "^5.4.5",
-    "mocha": "^6.0.0"
+    "mocha": "^10.4.0",
+    "typescript": "^5.4.5"
   },
   "scripts": {
     "tsc": "tsc",


### PR DESCRIPTION
Making package_json a PHONY target ensures that the presence of a package_json
file (if it ever were to happen) doesn't interfere with the task of updating the
version in package.json.

Closes #25.