### PR TITLE
allow reverse alignment of the stair layout

### DIFF
--- a/res/config.ui
+++ b/res/config.ui
@@ -198,7 +198,7 @@
                <item>
                 <widget class="QCheckBox" name="kcfg_stairReverse">
                  <property name="text">
-                  <string>Reverse the stair layout's orientation</string>
+                  <string>Reverse the stair layout's direction</string>
                  </property>
                 </widget>
                </item>

--- a/res/config.ui
+++ b/res/config.ui
@@ -182,6 +182,32 @@
            </widget>
           </item>
           <item>
+           <layout class="QVBoxLayout" name="stairLayoutConfigLayout">
+            <property name="leftMargin">
+             <number>20</number>
+            </property>
+            <property name="rightMargin">
+             <number>20</number>
+            </property>
+            <item>
+             <widget class="QGroupBox" name="groupBox_70">
+              <property name="title">
+               <string/>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_10">
+               <item>
+                <widget class="QCheckBox" name="kcfg_stairReverse">
+                 <property name="text">
+                  <string>Reverse the stair layout's orientation</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
            <widget class="QCheckBox" name="kcfg_enableFloatingLayout">
             <property name="text">
              <string>Floating Layout</string>

--- a/res/config.xml
+++ b/res/config.xml
@@ -46,6 +46,11 @@
         <default>true</default>
     </entry>
 
+    <entry name="stairReverse" type="Bool">
+	    <label>Reverse the stair layout's orientation</label>
+        <default>false</default>
+    </entry>
+
     <entry name="enableQuarterLayout" type="Bool">
 	    <label>Enable/disable Quarter layout</label>
         <default>false</default>

--- a/src/driver/kwin/kwinconfig.ts
+++ b/src/driver/kwin/kwinconfig.ts
@@ -24,7 +24,8 @@ class KWinConfig implements IConfig {
   public layoutFactories: { [key: string]: () => ILayout };
   public maximizeSoleTile: boolean;
   public monocleMaximize: boolean;
-  public monocleMinimizeRest: boolean; // kwin.specific
+  public monocleMinimizeRest: boolean;
+  public stairReverse: boolean; // kwin.specific
   //#endregion
 
   //#region Features
@@ -102,6 +103,7 @@ class KWinConfig implements IConfig {
     this.maximizeSoleTile = KWIN.readConfig("maximizeSoleTile", false);
     this.monocleMaximize = KWIN.readConfig("monocleMaximize", true);
     this.monocleMinimizeRest = KWIN.readConfig("monocleMinimizeRest", false);
+    this.stairReverse = KWIN.readConfig("stairReverse", false);
 
     this.adjustLayout = KWIN.readConfig("adjustLayout", true);
     this.adjustLayoutLive = KWIN.readConfig("adjustLayoutLive", true);

--- a/src/layouts/stairlayout.ts
+++ b/src/layouts/stairlayout.ts
@@ -40,11 +40,12 @@ class StairLayout implements ILayout {
 
     // TODO: limit the maximum number of staired windows.
 
+    const alignRight = Number(!KWINCONFIG.stairReverse);
     for (let i = 0; i < len; i++) {
       const dx = space * (len - i - 1);
       const dy = space * i;
       tiles[i].geometry = new Rect(
-        area.x + dx,
+        area.x + alignRight * dx,
         area.y + dy,
         area.width - dx,
         area.height - dy


### PR DESCRIPTION
My titlebar buttons are on the left, so the current stair layout only exposes the close button and therefore cannot be selected. I added a simple checkbox to offset the stairs the other way