### PR TITLE
Allow setup different layouts per virtual desktop

### DIFF
--- a/res/config.ui
+++ b/res/config.ui
@@ -809,7 +809,7 @@
           <item row="0" column="1">
            <widget class="QLineEdit" name="kcfg_screenDefaultLayout">
             <property name="toolTip">
-             <string>Comma-separated list OutputName:LayoutNumber all values you will see if run KSystemLog and type krohnkite in filter string. The data will right under Krohenkite start string. 2 monitors example:HDMI-A-1:3,DP-2:1</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Comma-separated list OutputName:LayoutNumber all values you will see if run KSystemLog and type krohnkite in filter string. The data will right under Krohenkite start string.&lt;/p&gt;&lt;p&gt;2 monitors example: HDMI-A-1:3,DP-2:1&lt;/p&gt;&lt;p&gt;Example with desktop name: HDMI-A-1:Desktop 1:1,HDMI-A-1:Desktop 2:3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
@@ -819,7 +819,7 @@
              <string>OutputName:LayoutId</string>
             </property>
            </widget>
-           </item>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/engine/layoutstore.ts
+++ b/src/engine/layoutstore.ts
@@ -28,20 +28,24 @@ class LayoutStoreEntry {
   private layouts: { [key: string]: ILayout };
   private previousID: string;
 
-  constructor(output_name: string) {
+  constructor(output_name: string, desktop_name?: string) {
     let layouts_str = CONFIG.layoutOrder.map(
       (layout, i) => i + "." + layout + ", "
     );
-    print(`Krohnkite: Screen(output):${output_name}, layouts: ${layouts_str}`);
+    print(`Krohnkite: Screen(output):${output_name}, Desktop(name):${desktop_name}, layouts: ${layouts_str}`);
     this.currentIndex = 0;
     this.currentID = CONFIG.layoutOrder[0];
 
     CONFIG.screenDefaultLayout.some((entry) => {
-      let [cfg_output, cfg_screen_id_str] = entry.split(":");
+      let cfg = entry.split(":");
+      let cfg_output = cfg[0];
+      let cfg_desktop = cfg.length == 2 ? undefined : cfg[1];
+      let cfg_screen_id_str = cfg.length == 2 ? cfg[1] : cfg[2];
       let cfg_screen_id = parseInt(cfg_screen_id_str);
 
       if (
-        output_name === cfg_output &&
+        (output_name === cfg_output || cfg_output === '') &&
+        (desktop_name === cfg_desktop || cfg_desktop === undefined) &&
         cfg_screen_id >= 0 &&
         cfg_screen_id < CONFIG.layoutOrder.length
       ) {
@@ -133,7 +137,8 @@ class LayoutStore {
         delete this.store[key_without_activity];
       } else {
         let output_name = key.slice(0, key.indexOf("@"));
-        this.store[key] = new LayoutStoreEntry(output_name);
+        let desktop_name = i2 !== -1 ? key.slice(i2 + 1) : undefined;
+        this.store[key] = new LayoutStoreEntry(output_name, desktop_name);
       }
     }
     return this.store[key];


### PR DESCRIPTION
I have 2 virtual desktops: 1 - for browser, players, etc; 2 - for development.

For 1st virtual desktop, I want to use **Monocle Layout**, to open all windows maximized.
For 2nd virtual desktop, I want to use **Tile layout**, to open debuggable process side-by-side to IDE.

This PR solve this case.