### PR TITLE
ignore more dialogs windows

### DIFF
--- a/res/config.xml
+++ b/res/config.xml
@@ -78,7 +78,7 @@
 
     <entry name="ignoreClass" type="String">
 	    <label>Ignore windows with certain classes(comma-separated list)</label>
-        <default>krunner,yakuake,spectacle,kded5,xwaylandvideobridge,plasmashell,ksplashqml</default>
+        <default>krunner,yakuake,spectacle,kded5,xwaylandvideobridge,plasmashell,ksplashqml,org.kde.plasmashell,org.kde.polkit-kde-authentication-agent-1</default>
     </entry>
 
     <entry name="ignoreRole" type="String">


### PR DESCRIPTION
### Changes
- Ignores dialogs like "clear clipboard history"
- Ignores policykit authentication windows (try running `pkexec ls` with and without the changes)