### PR TITLE
Change keepTilingOnDrag readConfig to match config.xml default

### DIFF
--- a/src/driver/kwin/kwinconfig.ts
+++ b/src/driver/kwin/kwinconfig.ts
@@ -115,7 +115,7 @@ class KWinConfig implements IConfig {
     this.adjustLayout = KWIN.readConfig("adjustLayout", true);
     this.adjustLayoutLive = KWIN.readConfig("adjustLayoutLive", true);
     this.keepFloatAbove = KWIN.readConfig("keepFloatAbove", true);
-    this.keepTilingOnDrag = KWIN.readConfig("keepTilingOnDrag", false);
+    this.keepTilingOnDrag = KWIN.readConfig("keepTilingOnDrag", true);
     this.noTileBorder = KWIN.readConfig("noTileBorder", false);
 
     this.limitTileWidthRatio = 0;


### PR DESCRIPTION
Fixes #70 

[In config.xml, the default radio button is true](https://github.com/anametologin/krohnkite/blob/master/res/config.xml#L163-L166), but the default for this value during the KWIN.readConfig() is false, which means the associated entry in kwinrc gets deleted when this entry is set to "true", and the intended config cannot be set in the KDE Settings application.