### PR TITLE
Add option to only tile selected windows

### DIFF
--- a/res/config.ui
+++ b/res/config.ui
@@ -997,6 +997,23 @@
             </property>
            </widget>
           </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="kcfg_tileNothing">
+            <property name="text">
+             <string>Always, except by class</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="kcfg_tilingClass">
+            <property name="toolTip">
+             <string>Comma-separated list of window classes. Matching windows will become tiled automatically.</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/res/config.xml
+++ b/res/config.xml
@@ -124,6 +124,16 @@
         <default></default>
     </entry>
 
+    <entry name="tileNothing" type="Bool">
+	    <label>Don't tile any windows by default</label>
+        <default>false</default>
+    </entry>
+
+    <entry name="tilingClass" type="String">
+	    <label>Tile windows with certain classes(comma-separated list)</label>
+        <default></default>
+    </entry>
+
     <entry name="floatingClass" type="String">
 	    <label>Float windows with certain classes(comma-separated list)</label>
         <default></default>

--- a/src/driver/kwin/kwinconfig.ts
+++ b/src/driver/kwin/kwinconfig.ts
@@ -75,6 +75,9 @@ class KWinConfig implements IConfig {
   public ignoreVDesktop: string[];
 
   public screenDefaultLayout: string[];
+
+  public tileNothing: boolean;
+  public tilingClass: string[];
   //#endregion
 
   constructor() {
@@ -171,6 +174,9 @@ class KWinConfig implements IConfig {
     this.screenDefaultLayout = commaSeparate(
       KWIN.readConfig("screenDefaultLayout", "")
     );
+
+    this.tilingClass = commaSeparate(KWIN.readConfig("tilingClass", ""));
+    this.tileNothing = KWIN.readConfig("tileNothing", false);
 
     if (this.preventMinimize && this.monocleMinimizeRest) {
       debug(

--- a/src/driver/kwin/kwinwindow.ts
+++ b/src/driver/kwin/kwinwindow.ts
@@ -46,7 +46,8 @@ class KWinWindow implements IDriverWindow {
       KWINCONFIG.ignoreClass.indexOf(resourceClass) >= 0 ||
       KWINCONFIG.ignoreClass.indexOf(resourceName) >= 0 ||
       matchWords(this.window.caption, KWINCONFIG.ignoreTitle) >= 0 ||
-      KWINCONFIG.ignoreRole.indexOf(windowRole) >= 0
+      KWINCONFIG.ignoreRole.indexOf(windowRole) >= 0 ||
+      (KWINCONFIG.tileNothing && KWINCONFIG.tilingClass.indexOf(resourceClass) < 0)
     );
   }
 


### PR DESCRIPTION
Coming from Awesome WM, I missed a feature to tile nothing by default except a specified list of applications.
This patch implements exactly this.

It adds two new settings in the rules tab: "Tile nothing by defaulf" and "Tile By Class".
If "Tile nothing by default" is checked, all windows will be ignored by default, except those with classes listed in "Tile By Class".