### PR TITLE
Fix Plasma lockscreen (META+L) has gaps the size of the dock

### DIFF
--- a/res/config.xml
+++ b/res/config.xml
@@ -102,7 +102,7 @@
 
     <entry name="ignoreClass" type="String">
 	    <label>Ignore windows with certain classes(comma-separated list)</label>
-        <default>krunner,yakuake,spectacle,kded5,xwaylandvideobridge,plasmashell,ksplashqml,org.kde.plasmashell,org.kde.polkit-kde-authentication-agent-1,org.kde.kruler,kruler,kwin_wayland,ksmserver-logout-greeter</default>
+        <default>krunner,yakuake,spectacle,kded5,xwaylandvideobridge,plasmashell,ksplashqml,org.kde.plasmashell,org.kde.polkit-kde-authentication-agent-1,org.kde.kruler,kruler,kwin_wayland,ksmserver-logout-greeter,kscreenlocker_greet</default>
     </entry>
 
     <entry name="ignoreRole" type="String">


### PR DESCRIPTION
Fix Plasma lockscreen (META+L) has gaps the size of the dock. Process name is kscreenlocker_greet (Archlinux)