### PR TITLE
ADDED: New layout - ThreeColumnsAlt with new window arrangement

### DIFF
--- a/docs/threecolumnsalt.md
+++ b/docs/threecolumnsalt.md
@@ -1,0 +1,87 @@
+# ThreeColumnLayout Alt
+
+This layout script provides an alternative to the ThreeColumnLayout. It arranges windows into up to three columns, depending on how many windows are present, and uses specific rules for placing them. I'm using an ultra wide screen (34:9) and i find this arrangement to be working the best for me.
+
+## Summary
+
+- **1 Window**  
+  Occupies the entire screen (conceptually "center").
+  
+- **2 Windows**  
+  Windows are placed in left and right columns.
+  
+- **3 Windows**  
+  Each column—left, center, right—has exactly one window (the exact order is configurable).
+  
+- **4+ Windows**  
+  Typically, the first two windows occupy two of the columns (e.g., left/right), and all subsequent windows stack in the remaining column.
+
+## How It Works
+
+### 1 Window
+
+    +-------------------------------------+
+    |                                     |
+    |           SINGLE WINDOW            |
+    |                                     |
+    +-------------------------------------+
+
+- If there is only one window open, it fills the entire workspace.
+- You can think of this as the "center," but practically it just takes the whole screen.
+
+### 2 Windows
+
+    +-----------------+-------------------+
+    |                 |                   |
+    |   WINDOW #1     |    WINDOW #2      |
+    |     (LEFT)      |      (RIGHT)      |
+    |                 |                   |
+    +-----------------+-------------------+
+
+- With two windows, the layout can split the screen into two equal columns (50%/50%) or any ratio you prefer.
+- By default, the first window goes to the **left**, and the second to the **right** (no center column used).
+
+### 3 Windows
+
+    +------------+------------+------------+
+    |  WINDOW #1 |  WINDOW #3 |  WINDOW #2 |
+    |    LEFT    |   MIDDLE   |   RIGHT    |
+    |            |            |            |
+    +------------+------------+------------+
+
+_The specific order—left, center, right—depends on how you configure it. Some may want #2 in the center, #3 on the right, etc._
+
+- The workspace is split into three columns (often 1/3 each).
+- Each column contains exactly **one** window—no stacking in this scenario.
+
+### 4+ Windows
+
+Example with 4 windows:
+
+    +------------+------------+------------+
+    |  WINDOW #1 |            |  WINDOW #2 |
+    |    LEFT    |   MIDDLE   |   RIGHT    |
+    +------------+            |            |
+    |            |  #3, #4... |            |
+    |            | (stacked)  |            |
+    +------------+------------+------------+
+
+- The first and second windows can occupy the left and right columns.
+- Any additional windows (#3, #4, etc.) stack vertically (or horizontally, if you prefer) in the remaining column.
+- This ensures only one column grows with more windows.
+
+## Configuration and Tips
+
+1. **Krohnkite Settings**  
+   - In *KWin Scripts → Krohnkite → Configure…*, set **“Position of new window”** to **Last** if you want new windows appended rather than promoted to master.  
+
+
+2. **Adjusting Column Widths**  
+   - By default, each column might be equally wide (1/3 each for three columns, 1/2 each for two columns). You can change the ratio arrays—like `[0.4, 0.3, 0.3]`—to give 40% of the width to one column and 30% to the others.
+
+3. **Preventing Manual Resizing**  
+   - `adjust()` method has been stripped but i'm planning on working on it
+
+4. **Consistent Window Order**  
+   - The array order (`tileables[0]`, `[1]`, `[2]`, etc.) determines which window goes to which column.  
+   - Make sure new windows are appended (i.e., “New Window Position” = End) so that your first window stays at index 0, second at 1, and so on. If windows appear in unexpected columns, confirm you’ve disabled “New window is master” and set “New window position” to “End.”

--- a/res/config.ui
+++ b/res/config.ui
@@ -208,6 +208,16 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="kcfg_enableThreeColumnAltLayout">
+            <property name="toolTip">
+             <string>Enable Three Column Alt layout</string>
+            </property>
+            <property name="text">
+             <string>Three Column Layout Alt</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="kcfg_enableSpiralLayout">
             <property name="text">
              <string>Spiral Layout</string>

--- a/res/config.xml
+++ b/res/config.xml
@@ -35,6 +35,11 @@
         <default>true</default>
     </entry>
 
+    <entry name="enableThreeColumnAltLayout" type="Bool">
+	    <label>Enable/disable Three Column layout Alt</label>
+        <default>true</default>
+    </entry>
+
     <entry name="enableSpiralLayout" type="Bool">
         <label>Enable/disable Spiral layout</label>
         <default>true</default>

--- a/res/shortcuts.qml
+++ b/res/shortcuts.qml
@@ -258,6 +258,9 @@ Item {
     function getThreeColumnLayout() {
         return treeColumnLayout;
     }
+    function getThreeColumnAltLayout() {
+        return treeColumnLayoutAlt;
+    }
     ShortcutHandler {
         id: treeColumnLayout;
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -103,6 +103,7 @@ interface IShortcuts {
   getTileLayout(): ShortcutHandler;
   getMonocleLayout(): ShortcutHandler;
   getThreeColumnLayout(): ShortcutHandler;
+  getThreeColumnAltLayout(): ShortcutHandler;
   getSpreadLayout(): ShortcutHandler;
   getStairLayout(): ShortcutHandler;
   getFloatingLayout(): ShortcutHandler;

--- a/src/driver/kwin/kwinconfig.ts
+++ b/src/driver/kwin/kwinconfig.ts
@@ -102,6 +102,7 @@ class KWinConfig implements IConfig {
         ["enableMonocleLayout", true, MonocleLayout],
         ["enableColumnsLayout", true, ColumnsLayout],
         ["enableThreeColumnLayout", true, ThreeColumnLayout],
+        ["enableThreeColumnAltLayout", true, ThreeColumnAltLayout],
         ["enableSpreadLayout", true, SpreadLayout],
         ["enableStairLayout", true, StairLayout],
         ["enableSpiralLayout", true, SpiralLayout],

--- a/src/driver/kwin/kwindriver.ts
+++ b/src/driver/kwin/kwindriver.ts
@@ -269,6 +269,9 @@ class KWinDriver implements IDriverContext {
       .getThreeColumnLayout()
       .activated.connect(callbackShortcutLayout(ThreeColumnLayout));
     this.shortcuts
+      .getThreeColumnAltLayout()
+      .activated.connect(callbackShortcutLayout(ThreeColumnAltLayout));  
+    this.shortcuts
       .getSpreadLayout()
       .activated.connect(callbackShortcutLayout(SpreadLayout));
     this.shortcuts

--- a/src/layouts/threecolumnsaltlayout.ts
+++ b/src/layouts/threecolumnsaltlayout.ts
@@ -1,0 +1,175 @@
+// Copyright (c) 2018-2019 Eon S. Jeon <esjeon@hyunmu.am>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+class ThreeColumnAltLayout implements ILayout {
+    public static readonly MIN_MASTER_RATIO = 0.2;
+    public static readonly MAX_MASTER_RATIO = 0.75;
+    public static readonly id = "ThreeColumnAltLayout";
+  
+    public readonly classID = ThreeColumnAltLayout.id;
+  
+    public get description(): string {
+      return "Three-Column-Alt [" + this.masterSize + "]";
+    }
+  
+    private masterRatio: number;
+    private masterSize: number;
+  
+    constructor() {
+      this.masterRatio = 0.6;
+      this.masterSize = 1;
+    }
+  
+    public adjust(
+      area: Rect,
+      tiles: WindowClass[],
+      basis: WindowClass,
+      delta: RectDelta
+  ): void {
+      // Ignore any manual adjustments so as not to break our sequence
+      return;
+  }
+  
+  
+      public apply(ctx: EngineContext, tileables: WindowClass[], area: Rect): void {
+        // 1) Force all windows to "Tiled" mode
+        tileables.forEach((tile) => (tile.state = WindowState.Tiled));
+    
+        const count = tileables.length;
+        if (count === 0) return; // No windows
+    
+        // === CASE 1: 1 WINDOW ===
+        // Place it in the "center" (fills the entire screen in practice)
+        if (count === 1) {
+            tileables[0].geometry = area;
+            return;
+        }
+    
+        // === CASE 2: 2 WINDOWS ===
+        // #1 on the left, #2 on the right (no center column in use)
+        if (count === 2) {
+            const [leftArea, rightArea] = LayoutUtils.splitAreaHalfWeighted(
+                area,
+                0.5,
+                CONFIG.tileLayoutGap,
+                true // true => vertical split (columns)
+            );
+    
+            tileables[0].geometry = leftArea;  // Window #1 on the left
+            tileables[1].geometry = rightArea; // Window #2 on the right
+            return;
+        }
+    
+        // === CASE 3: 3 WINDOWS ===
+        // #1 -> LEFT, #2 -> RIGHT, #3 (the latest) -> MIDDLE
+        // => split the screen into 3 equally sized columns
+        if (count === 3) {
+            const colRatios = [1/3, 1/3, 1/3];
+            const columns = LayoutUtils.splitAreaWeighted(
+                area,
+                colRatios,
+                CONFIG.tileLayoutGap,
+                true
+            );
+          // columns[0] => left, columns[1] => middle, columns[2] => right
+          // But we want: #1 -> left, #2 -> right, #3 -> middle.
+          tileables[0].geometry = columns[0]; // #1 left
+          tileables[2].geometry = columns[1]; // #3 middle
+          tileables[1].geometry = columns[2]; // #2 right
+            return;
+        }
+    
+        // === CASE 4+ WINDOWS ===
+        // #1 -> LEFT, #2 -> RIGHT,
+        // #3, #4, #5, ... -> MIDDLE COLUMN (stacked)
+        {
+          // Split into three equal columns
+          const colRatios = [1/3, 1/3, 1/3];
+          const [leftArea, middleArea, rightArea] = LayoutUtils.splitAreaWeighted(
+              area,
+              colRatios,
+              CONFIG.tileLayoutGap,
+              true
+          );
+
+          // #1 on the left, #2 on the right
+          tileables[0].geometry = leftArea;
+          tileables[1].geometry = rightArea;
+
+          // Everyone else (#3, #4, #5, etc.) goes into the middle, stacked vertically
+          const middleStack = tileables.slice(2); // from the 3rd onward
+          LayoutUtils.splitAreaWeighted(
+              middleArea,
+              middleStack.map(t => t.weight),
+              CONFIG.tileLayoutGap
+          ).forEach((subRect, i) => {
+              middleStack[i].geometry = subRect;
+          });
+      }
+    }      
+  
+    public clone(): ILayout {
+      const other = new ThreeColumnAltLayout();
+      other.masterRatio = this.masterRatio;
+      other.masterSize = this.masterSize;
+      return other;
+    }
+  
+    public handleShortcut(
+      ctx: EngineContext,
+      input: Shortcut,
+      data?: any
+    ): boolean {
+      switch (input) {
+        case Shortcut.Increase:
+          this.resizeMaster(ctx, +1);
+          return true;
+        case Shortcut.Decrease:
+          this.resizeMaster(ctx, -1);
+          return true;
+        case Shortcut.DWMLeft:
+          this.masterRatio = clip(
+            slide(this.masterRatio, -0.05),
+            ThreeColumnAltLayout.MIN_MASTER_RATIO,
+            ThreeColumnAltLayout.MAX_MASTER_RATIO
+          );
+          return true;
+        case Shortcut.DWMRight:
+          this.masterRatio = clip(
+            slide(this.masterRatio, +0.05),
+            ThreeColumnAltLayout.MIN_MASTER_RATIO,
+            ThreeColumnAltLayout.MAX_MASTER_RATIO
+          );
+          return true;
+        default:
+          return false;
+      }
+    }
+  
+    public toString(): string {
+      return "ThreeColumnAltLayout(nmaster=" + this.masterSize + ")";
+    }
+  
+    private resizeMaster(ctx: EngineContext, step: -1 | 1): void {
+      this.masterSize = clip(this.masterSize + step, 1, 10);
+      ctx.showNotification(this.description);
+    }
+  }
+  


### PR DESCRIPTION
[demo-3columnAlt.webm](https://github.com/user-attachments/assets/7f2210ef-11f3-41ab-80bf-13d0a0b2d632)

# ThreeColumnLayout Alt

This layout script provides an alternative to the ThreeColumnLayout. It arranges windows into up to three columns, depending on how many windows are present, and uses specific rules for placing them. I'm using an ultra wide screen (34:9) and i find this arrangement to be working the best for me. I also added a doc folder as I think it would be good to add some documentation around each layout. 

## Summary

- **1 Window**  
  Occupies the entire screen (conceptually "center").
  
- **2 Windows**  
  Windows are placed in left and right columns.
  
- **3 Windows**  
  Each column—left, center, right—has exactly one window (the exact order is configurable).
  
- **4+ Windows**  
  Typically, the first two windows occupy two of the columns (e.g., left/right), and all subsequent windows stack in the remaining column.

## How It Works

### 1 Window

    +-------------------------------------+
    |                                     |
    |           SINGLE WINDOW            |
    |                                     |
    +-------------------------------------+

- If there is only one window open, it fills the entire workspace.
- You can think of this as the "center," but practically it just takes the whole screen.

### 2 Windows

    +-----------------+-------------------+
    |                 |                   |
    |   WINDOW #1     |    WINDOW #2      |
    |     (LEFT)      |      (RIGHT)      |
    |                 |                   |
    +-----------------+-------------------+

- With two windows, the layout can split the screen into two equal columns (50%/50%) or any ratio you prefer.
- By default, the first window goes to the **left**, and the second to the **right** (no center column used).

### 3 Windows

    +------------+------------+------------+
    |  WINDOW #1 |  WINDOW #3 |  WINDOW #2 |
    |    LEFT    |   MIDDLE   |   RIGHT    |
    |            |            |            |
    +------------+------------+------------+

_The specific order—left, center, right—depends on how you configure it. Some may want #2 in the center, #3 on the right, etc._

- The workspace is split into three columns (often 1/3 each).
- Each column contains exactly **one** window—no stacking in this scenario.

### 4+ Windows

Example with 4 windows:

    +------------+------------+------------+
    |  WINDOW #1 |            |  WINDOW #2 |
    |    LEFT    |   MIDDLE   |   RIGHT    |
    +------------+            |            |
    |            |  #3, #4... |            |
    |            | (stacked)  |            |
    +------------+------------+------------+

- The first and second windows can occupy the left and right columns.
- Any additional windows (#3, #4, etc.) stack vertically (or horizontally, if you prefer) in the remaining column.
- This ensures only one column grows with more windows.

## Configuration and Tips

1. **Krohnkite Settings**  
   - In *KWin Scripts → Krohnkite → Configure…*, set **“Position of new window”** to **Last** if you want new windows appended rather than promoted to master.  

2. **Adjusting Column Widths**  
   - By default, each column might be equally wide (1/3 each for three columns, 1/2 each for two columns). You can change the ratio arrays—like `[0.4, 0.3, 0.3]`—to give 40% of the width to one column and 30% to the others.

