### PR TITLE
Add an option to change the duration of pop-up notifications

### DIFF
--- a/res/config.ui
+++ b/res/config.ui
@@ -1262,6 +1262,54 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBox_13">
+         <property name="title">
+          <string>Notifications</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_12">
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="kcfg_notificationDuration">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the time (in milliseconds) for how long a pop-up notification will remain visible before it automatically disappears. A value of 0 will disable notifications.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="suffix">
+             <string> ms</string>
+            </property>
+            <property name="maximum">
+             <number>9999</number>
+            </property>
+            <property name="singleStep">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>1000</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_18">
+            <property name="text">
+             <string>Duration  </string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <spacer name="horizontalSpacer_4">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="kcfg_noTileBorder">
          <property name="toolTip">
           <string>All tiled windows will have no borders. Borders will be added back if window become float.</string>
@@ -1299,29 +1347,6 @@
          </property>
          <property name="text">
           <string>Get actual mouse position using xdotool while resizing (HACK)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_17">
-         <property name="text">
-          <string>Duration of pop-up notifications</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QSpinBox" name="kcfg_notificationDuration">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the time (in milliseconds) for how long a pop-up notification will remain visible before it automatically disappears. A value of 0 will disable notifications.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> ms</string>
-         </property>
-         <property name="maximum">
-          <number>10000</number>
-         </property>
-         <property name="singleStep">
-          <number>100</number>
          </property>
         </widget>
        </item>

--- a/res/config.ui
+++ b/res/config.ui
@@ -1293,6 +1293,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="kcfg_displayLayoutNotification">
+         <property name="text">
+          <string>Display a notification when the layout changes</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="kcfg_pollMouseXdotool">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, actual mouse position will be used for certain operations. (e.g. swapping tile by dragging)&lt;/p&gt;&lt;p&gt;To use this feature, user &lt;span style=&quot; text-decoration: underline;&quot;&gt;MUST make sure &lt;/span&gt;&lt;span style=&quot; font-weight:600; font-style:italic; text-decoration: underline;&quot;&gt;xdotool &lt;/span&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;is installed&lt;/span&gt; on the system.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>

--- a/res/config.ui
+++ b/res/config.ui
@@ -1294,6 +1294,9 @@
        </item>
        <item>
         <widget class="QCheckBox" name="kcfg_displayLayoutNotification">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, a notification will be displayed telling the user what layout is currently active.&lt;/p&gt;&lt;p&gt;The notification appears whenever the layout changes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
          <property name="text">
           <string>Display a notification when the layout changes</string>
          </property>

--- a/res/config.ui
+++ b/res/config.ui
@@ -1293,22 +1293,35 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="kcfg_displayLayoutNotification">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, a notification will be displayed telling the user what layout is currently active.&lt;/p&gt;&lt;p&gt;The notification appears whenever the layout changes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Display a notification when the layout changes</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="kcfg_pollMouseXdotool">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, actual mouse position will be used for certain operations. (e.g. swapping tile by dragging)&lt;/p&gt;&lt;p&gt;To use this feature, user &lt;span style=&quot; text-decoration: underline;&quot;&gt;MUST make sure &lt;/span&gt;&lt;span style=&quot; font-weight:600; font-style:italic; text-decoration: underline;&quot;&gt;xdotool &lt;/span&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;is installed&lt;/span&gt; on the system.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="text">
           <string>Get actual mouse position using xdotool while resizing (HACK)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_17">
+         <property name="text">
+          <string>Duration of pop-up notifications</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="kcfg_notificationDuration">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the time (in milliseconds) for how long a pop-up notification will remain visible before it automatically disappears. A value of 0 will disable notifications.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="suffix">
+          <string> ms</string>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+         <property name="singleStep">
+          <number>100</number>
          </property>
         </widget>
        </item>

--- a/res/config.xml
+++ b/res/config.xml
@@ -239,9 +239,9 @@
         <default>true</default>
     </entry>
 
-    <entry name="displayLayoutNotification" type="Bool">
-	    <label>Display a notification when the layout changes</label>
-        <default>true</default>
+    <entry name="notificationDuration" type="Int">
+	    <label>Duration of pop-up notifications</label>
+        <default>1000</default>
     </entry>
 
     <entry name="screenGapLeft" type="Int">

--- a/res/config.xml
+++ b/res/config.xml
@@ -239,6 +239,11 @@
         <default>true</default>
     </entry>
 
+    <entry name="displayLayoutNotification" type="Bool">
+	    <label>Display a notification when the layout changes</label>
+        <default>true</default>
+    </entry>
+
     <entry name="screenGapLeft" type="Int">
         <label>Gap between tiles and screen borders (Left)</label>
         <default>0</default>

--- a/res/main.qml
+++ b/res/main.qml
@@ -42,9 +42,9 @@ Item {
         id: popupDialog
         source: "popup.qml"
 
-        function show(text) {
+        function show(text, duration) {
             var area = Workspace.clientArea(KWin.FullScreenArea, Workspace.activeScreen, Workspace.currentDesktop);
-            this.item.show(text, area, 1000);
+            this.item.show(text, area, duration);
         }
     }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -138,6 +138,7 @@ interface IConfig {
   tiledWindowsLayer: WindowLayer;
   keepTilingOnDrag: boolean;
   noTileBorder: boolean;
+  displayLayoutNotification: boolean;
   limitTileWidthRatio: number;
   //#endregion
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -138,7 +138,7 @@ interface IConfig {
   tiledWindowsLayer: WindowLayer;
   keepTilingOnDrag: boolean;
   noTileBorder: boolean;
-  displayLayoutNotification: boolean;
+  notificationDuration: number;
   limitTileWidthRatio: number;
   //#endregion
 

--- a/src/driver/kwin/kwinconfig.ts
+++ b/src/driver/kwin/kwinconfig.ts
@@ -42,6 +42,7 @@ class KWinConfig implements IConfig {
   public adjustLayout: boolean;
   public adjustLayoutLive: boolean;
   public keepTilingOnDrag: boolean;
+  public displayLayoutNotification: boolean;
   public noTileBorder: boolean;
   public limitTileWidthRatio: number;
   //#endregion
@@ -172,6 +173,7 @@ class KWinConfig implements IConfig {
     this.floatUtility = KWIN.readConfig("floatUtility", true);
     this.preventMinimize = KWIN.readConfig("preventMinimize", false);
     this.preventProtrusion = KWIN.readConfig("preventProtrusion", true);
+    this.displayLayoutNotification = KWIN.readConfig("displayLayoutNotification", true);
     this.pollMouseXdotool = KWIN.readConfig("pollMouseXdotool", false);
 
     this.floatingClass = commaSeparate(KWIN.readConfig("floatingClass", ""));

--- a/src/driver/kwin/kwinconfig.ts
+++ b/src/driver/kwin/kwinconfig.ts
@@ -42,7 +42,7 @@ class KWinConfig implements IConfig {
   public adjustLayout: boolean;
   public adjustLayoutLive: boolean;
   public keepTilingOnDrag: boolean;
-  public displayLayoutNotification: boolean;
+  public notificationDuration: number;
   public noTileBorder: boolean;
   public limitTileWidthRatio: number;
   //#endregion
@@ -173,7 +173,7 @@ class KWinConfig implements IConfig {
     this.floatUtility = KWIN.readConfig("floatUtility", true);
     this.preventMinimize = KWIN.readConfig("preventMinimize", false);
     this.preventProtrusion = KWIN.readConfig("preventProtrusion", true);
-    this.displayLayoutNotification = KWIN.readConfig("displayLayoutNotification", true);
+    this.notificationDuration = KWIN.readConfig("notificationDuration", 1000);
     this.pollMouseXdotool = KWIN.readConfig("pollMouseXdotool", false);
 
     this.floatingClass = commaSeparate(KWIN.readConfig("floatingClass", ""));

--- a/src/driver/kwin/kwindriver.ts
+++ b/src/driver/kwin/kwindriver.ts
@@ -167,7 +167,8 @@ class KWinDriver implements IDriverContext {
   }
 
   public showNotification(text: string) {
-    popupDialog.show(text);
+    if (CONFIG.notificationDuration > 0)
+      popupDialog.show(text, CONFIG.notificationDuration);
   }
   //#endregion
 

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -480,7 +480,8 @@ class TilingEngine {
    */
   public cycleLayout(ctx: IDriverContext, step: 1 | -1) {
     const layout = this.layouts.cycleLayout(ctx.currentSurface, step);
-    if (layout) ctx.showNotification(layout.description);
+    if (layout && CONFIG.displayLayoutNotification)
+      ctx.showNotification(layout.description);
   }
 
   /**
@@ -488,7 +489,8 @@ class TilingEngine {
    */
   public setLayout(ctx: IDriverContext, layoutClassID: string) {
     const layout = this.layouts.setLayout(ctx.currentSurface, layoutClassID);
-    if (layout) ctx.showNotification(layout.description);
+    if (layout && CONFIG.displayLayoutNotification)
+      ctx.showNotification(layout.description);
   }
 
   /**

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -480,8 +480,7 @@ class TilingEngine {
    */
   public cycleLayout(ctx: IDriverContext, step: 1 | -1) {
     const layout = this.layouts.cycleLayout(ctx.currentSurface, step);
-    if (layout && CONFIG.displayLayoutNotification)
-      ctx.showNotification(layout.description);
+    if (layout) ctx.showNotification(layout.description);
   }
 
   /**
@@ -489,8 +488,7 @@ class TilingEngine {
    */
   public setLayout(ctx: IDriverContext, layoutClassID: string) {
     const layout = this.layouts.setLayout(ctx.currentSurface, layoutClassID);
-    if (layout && CONFIG.displayLayoutNotification)
-      ctx.showNotification(layout.description);
+    if (layout) ctx.showNotification(layout.description);
   }
 
   /**

--- a/src/extern/global.d.ts
+++ b/src/extern/global.d.ts
@@ -37,7 +37,7 @@ declare var mousePoller: Plasma.PlasmaCore.DataSource;
 declare var scriptRoot: object;
 
 interface PopupDialog {
-  show(text: string): void;
+  show(text: string, duration: number): void;
 }
 declare var popupDialog: PopupDialog;
 


### PR DESCRIPTION
Currently, pop-up notifications are [hard-coded](https://github.com/anametologin/krohnkite/blob/fbbe60663bd30dd6ffe8ec44dcda97a8fa4ba2b2/res/main.qml#L47) to last exactly 1000 ms. This patch adds an option to change the duration of notifications, including the ability to disable them completely (0 ms).

I wanted this option because I find the notifications distracting rather than helpful. They also seem to block keyboard input to other windows on my setup until they disappear.

<img src="https://github.com/user-attachments/assets/a8dbd553-7d38-4230-8214-b42bc2458edd" height="500"></img>