### PR TITLE
Fix gaps in HalfSplitLayoutPart

### DIFF
--- a/src/layouts/layoutpart.ts
+++ b/src/layouts/layoutpart.ts
@@ -65,7 +65,6 @@ class HalfSplitLayoutPart<L extends ILayoutPart, R extends ILayoutPart>
    */
   public angle: 0 | 90 | 180 | 270;
 
-  public gap: number;
   public primarySize: number;
   public ratio: number;
 
@@ -79,7 +78,6 @@ class HalfSplitLayoutPart<L extends ILayoutPart, R extends ILayoutPart>
 
   constructor(public primary: L, public secondary: R) {
     this.angle = 0;
-    this.gap = 0;
     this.primarySize = 1;
     this.ratio = 0.5;
   }
@@ -127,7 +125,7 @@ class HalfSplitLayoutPart<L extends ILayoutPart, R extends ILayoutPart>
       this.ratio = LayoutUtils.adjustAreaHalfWeights(
         area,
         this.reversed ? 1 - this.ratio : this.ratio,
-        this.gap,
+        gap,
         this.reversed ? 1 - targetIndex : targetIndex,
         delta,
         this.horizontal
@@ -169,7 +167,7 @@ class HalfSplitLayoutPart<L extends ILayoutPart, R extends ILayoutPart>
       const [area1, area2] = LayoutUtils.splitAreaHalfWeighted(
         area,
         ratio,
-        this.gap,
+        gap,
         this.horizontal
       );
       const result1 = this.primary.apply(


### PR DESCRIPTION
Commit 863be0a introduced a gap argument to methods to be used instead of the gap property. HalfSplitLayoutPart still retained the gap property though, which is never set to anything other than 0. This was used in the adjust and apply methods and so clobbered the gap between primary and secondary windows. This commit removes the gap property from HalfSplitLayoutPart and standardises on using the gap argument passed to the method.