### PR TITLE
Bring all tiled windows to the front at once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /pkg/
 /node_modules/
 /builds/
+/.idea/
 /.task/
 
 /TODO.md

--- a/res/config.ui
+++ b/res/config.ui
@@ -3317,6 +3317,13 @@
             </item>
            </widget>
           </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="kcfg_raiseAllMosaicTileWindowsAtOnce">
+            <property name="text">
+             <string>Bring all tiled windows to the front at once</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/res/config.xml
+++ b/res/config.xml
@@ -274,6 +274,11 @@
         <default>1</default>
     </entry>
 
+    <entry name="raiseAllMosaicTileWindowsAtOnce" type="Bool">
+        <label>When a tiled window gains focus, bring all others to the same layer</label>
+        <default>true</default>
+    </entry>
+
     <entry name="soleWindowWidth" type="Int">
 	    <label>The sole window width in percent.</label>
         <default>100</default>

--- a/src/common.ts
+++ b/src/common.ts
@@ -158,6 +158,7 @@ interface IConfig {
   adjustLayoutLive: boolean;
   floatedWindowsLayer: WindowLayer;
   tiledWindowsLayer: WindowLayer;
+  raiseAllMosaicTileWindowsAtOnce: boolean;
   keepTilingOnDrag: boolean;
   noTileBorder: boolean;
   notificationDuration: number;
@@ -197,6 +198,7 @@ interface IDriverWindow {
   surface: ISurface;
 
   commit(geometry?: Rect, noBorder?: boolean, windowLayer?: WindowLayer): void;
+  raise(): void;
   visible(srf: ISurface): boolean;
 }
 

--- a/src/driver/kwin/kwinconfig.ts
+++ b/src/driver/kwin/kwinconfig.ts
@@ -50,6 +50,7 @@ class KWinConfig implements IConfig {
   public columnsLayerConf: string[];
   public tiledWindowsLayer: number;
   public floatedWindowsLayer: number;
+  public raiseAllMosaicTileWindowsAtOnce: boolean;
   public monocleMaximize: boolean;
   public monocleMinimizeRest: boolean;
   public stairReverse: boolean; // kwin.specific
@@ -220,6 +221,7 @@ class KWinConfig implements IConfig {
     this.floatedWindowsLayer = getWindowLayer(
       KWIN.readConfig("floatedWindowsLayer", 1)
     );
+    this.raiseAllMosaicTileWindowsAtOnce = KWIN.readConfig("raiseAllMosaicTileWindowsAtOnce", true);
     this.quarterLayoutReset = KWIN.readConfig("quarterLayoutReset", false);
     this.monocleMaximize = KWIN.readConfig("monocleMaximize", true);
     this.monocleMinimizeRest = KWIN.readConfig("monocleMinimizeRest", false);

--- a/src/driver/kwin/kwindriver.ts
+++ b/src/driver/kwin/kwindriver.ts
@@ -393,15 +393,21 @@ class KWinDriver implements IDriverContext {
       (window.window as KWinWindow).maximized = maximized;
       this.control.onWindowMaximizeChanged(this, window, maximized);
     });
+
     this.connect(client.minimizedChanged, () => {
       if (KWINCONFIG.preventMinimize) {
         client.minimized = false;
         this.workspace.activeWindow = client;
+
+      } else if (client.minimized) {
+        this.control.onWindowChanged(this, window, "minimized");
+
       } else {
-        var comment = client.minimized ? "minimized" : "unminimized";
-        this.control.onWindowChanged(this, window, comment);
+        this.control.onWindowChanged(this, window, "unminimized");
+        this.control.onWindowFocused(this, window);
       }
     });
+
     this.connect(client.fullScreenChanged, () =>
       this.control.onWindowChanged(
         this,

--- a/src/driver/kwin/kwinwindow.ts
+++ b/src/driver/kwin/kwinwindow.ts
@@ -210,6 +210,10 @@ class KWinWindow implements IDriverWindow {
     }
   }
 
+  public raise() {
+    this.workspace.raiseWindow(this.window);
+  }
+
   public toString(): string {
     /* using a shorthand name to keep debug message tidy */
     return (

--- a/src/engine/control.ts
+++ b/src/engine/control.ts
@@ -242,7 +242,16 @@ class TilingController {
 
   public onWindowFocused(ctx: IDriverContext, window: WindowClass) {
     window.timestamp = new Date().getTime();
+
+    if (CONFIG.raiseAllMosaicTileWindowsAtOnce && window.isMosaicTile) {
+      this.engine.windows.getVisibleWindows(ctx.currentSurface)
+          .filter(w => w.isMosaicTile)
+          .forEach(w => {
+            w.window.raise();
+          });
+    }
   }
+
   public onDesktopsChanged(ctx: IDriverContext, window: WindowClass) {
     if (window.state !== WindowState.Docked)
       window.state = WindowState.Undecided;

--- a/src/engine/window.ts
+++ b/src/engine/window.ts
@@ -67,6 +67,16 @@ class WindowClass {
     return this.window.shouldIgnore;
   }
 
+  /**
+   * Intent:
+   * - On a given surface, there is (at most) one set of non-maximised windows
+   *   that fills the whole surface. It comprises a main layout, and docked
+   *   windows if there are any.
+   * - This method returns whether this window is part of that set.
+   */
+  public get isMosaicTile(): boolean {
+    return (this.state === WindowState.Docked || this.state === WindowState.Tiled);
+  }
   /** If this window ***can be*** tiled by layout. */
   public get tileable(): boolean {
     return WindowClass.isTileableState(this.state);


### PR DESCRIPTION
As a user who uses both tiled and floating/maximized windows, I set both types to the Normal layer so I can see tiled windows without minimizing all non-tiled ones, and conversely.

However, it can then happen that some tiled windows are behind floating windows and other tiled windows are in front, which is rather messy:

![Copie d'écran_20250511_232040](https://github.com/user-attachments/assets/fe2b8c86-296f-4ca3-aecb-318e09e2586a)

So I propose this behavior: whenever a tiled window gets the focus (and is presumably brought to the front), all of them are brought to the front too.

By "tiled", here I mean "part of the main mosaic of non-maximized windows that fills the surface", that is to say, the main layout + docked windows. Honestly, I have no idea how to name this. "Mosaic"? "Full layout"? ...