### PR TITLE
fix: correct shortcut name capitalisation

### DIFF
--- a/res/shortcuts.qml
+++ b/res/shortcuts.qml
@@ -9,7 +9,7 @@ Item {
     ShortcutHandler {
         id: toggleDock;
 
-        name: "KrohnkitetoggleDock";
+        name: "KrohnkiteToggleDock";
         text: "Krohnkite: Toggle Dock";
         sequence: "";
     }
@@ -151,7 +151,7 @@ Item {
     ShortcutHandler {
         id: growWidth;
 
-        name: "KrohnkitegrowWidth";
+        name: "KrohnkiteGrowWidth";
         text: "Krohnkite: Grow Width";
         sequence: "Meta+Ctrl+L";
     }


### PR DESCRIPTION
Standardizes the shortcut names in `res/shortcuts.qml` to use a consistent PascalCase format.