### PR TITLE
Move window across multiple monitors

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -225,6 +225,7 @@ interface IDriverContext {
 
   currentSurface: ISurface;
   currentWindow: WindowClass | null;
+  workspace: Workspace;
 
   setTimeout(func: () => void, timeout: number): void;
   showNotification(text: string): void;

--- a/src/engine/control.ts
+++ b/src/engine/control.ts
@@ -249,30 +249,38 @@ class TilingController {
     if (CONFIG.directionalKeyMode === "dwm") {
       switch (input) {
         case Shortcut.FocusUp:
+          console.log("dwm Shortcut.FocusUp")
           input = Shortcut.FocusNext;
           break;
         case Shortcut.FocusDown:
+          console.log("dwm Shortcut.FocusDown")
           input = Shortcut.FocusPrev;
           break;
         case Shortcut.FocusLeft:
+          console.log("dwm Shortcut.FocusLeft")
           input = Shortcut.DWMLeft;
           break;
         case Shortcut.FocusRight:
+          console.log("dwm Shortcut.FocusRight")
           input = Shortcut.DWMRight;
           break;
       }
     } else if (CONFIG.directionalKeyMode === "focus") {
       switch (input) {
         case Shortcut.ShiftUp:
+          console.log("dwm Shortcut.ShiftUp")
           input = Shortcut.SwapUp;
           break;
         case Shortcut.ShiftDown:
+          console.log("dwm Shortcut.ShiftDown")
           input = Shortcut.SwapDown;
           break;
         case Shortcut.ShiftLeft:
+          console.log("dwm Shortcut.ShiftLeft")
           input = Shortcut.SwapLeft;
           break;
         case Shortcut.ShiftRight:
+          console.log("dwm Shortcut.ShiftRight")
           input = Shortcut.SwapRight;
           break;
       }
@@ -293,24 +301,32 @@ class TilingController {
 
     switch (input) {
       case Shortcut.FocusNext:
+        console.log("Shortcut.FocusNext")
         this.engine.focusOrder(ctx, +1);
         break;
       case Shortcut.FocusPrev:
+        console.log("Shortcut.FocusPrev")
         this.engine.focusOrder(ctx, -1);
         break;
 
       case Shortcut.FocusUp:
+        console.log("Shortcut.FocusUp")
         this.engine.focusDir(ctx, "up");
         break;
       case Shortcut.FocusDown:
+        console.log("Shortcut.FocusDown")
         this.engine.focusDir(ctx, "down");
         break;
       case Shortcut.DWMLeft:
+        console.log("Shortcut.DWMLeft")
       case Shortcut.FocusLeft:
+        console.log("Shortcut.FocusLeft")
         this.engine.focusDir(ctx, "left");
         break;
       case Shortcut.DWMRight:
+        console.log("Shortcut.DWMRight")
       case Shortcut.FocusRight:
+        console.log("Shortcut.FocusRight")
         this.engine.focusDir(ctx, "right");
         break;
 
@@ -384,22 +400,28 @@ class TilingController {
         break;
 
       case Shortcut.ShiftUp:
+      console.log("Normal? Shortcut.ShiftUp")
         if (window) this.engine.swapOrder(window, -1);
         break;
       case Shortcut.ShiftDown:
+      console.log("Normal? Shortcut.ShiftDown")
         if (window) this.engine.swapOrder(window, +1);
         break;
 
       case Shortcut.SwapUp:
+      console.log("Normal? Shortcut.SwapUp")
         this.engine.swapDirOrMoveFloat(ctx, "up");
         break;
       case Shortcut.SwapDown:
+      console.log("Normal? Shortcut.SwapDown")
         this.engine.swapDirOrMoveFloat(ctx, "down");
         break;
       case Shortcut.SwapLeft:
+      console.log("Normal? Shortcut.SwapLeft")
         this.engine.swapDirOrMoveFloat(ctx, "left");
         break;
       case Shortcut.SwapRight:
+      console.log("Normal? Shortcut.SwapRight")
         this.engine.swapDirOrMoveFloat(ctx, "right");
         break;
 

--- a/src/engine/control.ts
+++ b/src/engine/control.ts
@@ -249,38 +249,30 @@ class TilingController {
     if (CONFIG.directionalKeyMode === "dwm") {
       switch (input) {
         case Shortcut.FocusUp:
-          console.log("dwm Shortcut.FocusUp")
           input = Shortcut.FocusNext;
           break;
         case Shortcut.FocusDown:
-          console.log("dwm Shortcut.FocusDown")
           input = Shortcut.FocusPrev;
           break;
         case Shortcut.FocusLeft:
-          console.log("dwm Shortcut.FocusLeft")
           input = Shortcut.DWMLeft;
           break;
         case Shortcut.FocusRight:
-          console.log("dwm Shortcut.FocusRight")
           input = Shortcut.DWMRight;
           break;
       }
     } else if (CONFIG.directionalKeyMode === "focus") {
       switch (input) {
         case Shortcut.ShiftUp:
-          console.log("dwm Shortcut.ShiftUp")
           input = Shortcut.SwapUp;
           break;
         case Shortcut.ShiftDown:
-          console.log("dwm Shortcut.ShiftDown")
           input = Shortcut.SwapDown;
           break;
         case Shortcut.ShiftLeft:
-          console.log("dwm Shortcut.ShiftLeft")
           input = Shortcut.SwapLeft;
           break;
         case Shortcut.ShiftRight:
-          console.log("dwm Shortcut.ShiftRight")
           input = Shortcut.SwapRight;
           break;
       }
@@ -301,32 +293,24 @@ class TilingController {
 
     switch (input) {
       case Shortcut.FocusNext:
-        console.log("Shortcut.FocusNext")
         this.engine.focusOrder(ctx, +1);
         break;
       case Shortcut.FocusPrev:
-        console.log("Shortcut.FocusPrev")
         this.engine.focusOrder(ctx, -1);
         break;
 
       case Shortcut.FocusUp:
-        console.log("Shortcut.FocusUp")
         this.engine.focusDir(ctx, "up");
         break;
       case Shortcut.FocusDown:
-        console.log("Shortcut.FocusDown")
         this.engine.focusDir(ctx, "down");
         break;
       case Shortcut.DWMLeft:
-        console.log("Shortcut.DWMLeft")
       case Shortcut.FocusLeft:
-        console.log("Shortcut.FocusLeft")
         this.engine.focusDir(ctx, "left");
         break;
       case Shortcut.DWMRight:
-        console.log("Shortcut.DWMRight")
       case Shortcut.FocusRight:
-        console.log("Shortcut.FocusRight")
         this.engine.focusDir(ctx, "right");
         break;
 
@@ -400,28 +384,22 @@ class TilingController {
         break;
 
       case Shortcut.ShiftUp:
-      console.log("Normal? Shortcut.ShiftUp")
         if (window) this.engine.swapOrder(window, -1);
         break;
       case Shortcut.ShiftDown:
-      console.log("Normal? Shortcut.ShiftDown")
         if (window) this.engine.swapOrder(window, +1);
         break;
 
       case Shortcut.SwapUp:
-      console.log("Normal? Shortcut.SwapUp")
         this.engine.swapDirOrMoveFloat(ctx, "up");
         break;
       case Shortcut.SwapDown:
-      console.log("Normal? Shortcut.SwapDown")
         this.engine.swapDirOrMoveFloat(ctx, "down");
         break;
       case Shortcut.SwapLeft:
-      console.log("Normal? Shortcut.SwapLeft")
         this.engine.swapDirOrMoveFloat(ctx, "left");
         break;
       case Shortcut.SwapRight:
-      console.log("Normal? Shortcut.SwapRight")
         this.engine.swapDirOrMoveFloat(ctx, "right");
         break;
 

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -473,6 +473,7 @@ class TilingEngine {
             ctx.workspace.slotWindowToNextScreen();
             break;
       }
+      window.state = WindowState.Tiled;
     }
   }
 

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -456,7 +456,41 @@ class TilingEngine {
     }
 
     const neighbor = this.getNeighborByDirection(ctx, window, dir);
-    if (neighbor) this.windows.swap(window, neighbor);
+    console.log(neighbor)
+    if (neighbor) {
+      this.windows.swap(window, neighbor)
+    } else {
+        switch (dir) {
+          case "up":
+            console.log("--------------------------");
+            console.log("> Up");
+            console.log(ctx.workspace);
+            ctx.workspace.slotWindowToAboveScreen();
+            console.log("--------------------------");
+            break;
+          case "down":
+            console.log("--------------------------");
+            console.log("> Down");
+            console.log(ctx.workspace);
+            ctx.workspace.slotWindowToBelowScreen();
+            console.log("--------------------------");
+            break;
+          case "left":
+            console.log("--------------------------");
+            console.log("> Left");
+            console.log(ctx.workspace);
+            ctx.workspace.slotWindowToPrevScreen();
+            console.log("--------------------------");
+            break;
+          case "right":
+            console.log("--------------------------");
+            console.log("> Right");
+            console.log(ctx.workspace);
+            ctx.workspace.slotWindowToNextScreen();
+            console.log("--------------------------");
+            break;
+      }
+    }
   }
 
   /**

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -456,38 +456,21 @@ class TilingEngine {
     }
 
     const neighbor = this.getNeighborByDirection(ctx, window, dir);
-    console.log(neighbor)
     if (neighbor) {
       this.windows.swap(window, neighbor)
     } else {
         switch (dir) {
           case "up":
-            console.log("--------------------------");
-            console.log("> Up");
-            console.log(ctx.workspace);
             ctx.workspace.slotWindowToAboveScreen();
-            console.log("--------------------------");
             break;
           case "down":
-            console.log("--------------------------");
-            console.log("> Down");
-            console.log(ctx.workspace);
             ctx.workspace.slotWindowToBelowScreen();
-            console.log("--------------------------");
             break;
           case "left":
-            console.log("--------------------------");
-            console.log("> Left");
-            console.log(ctx.workspace);
             ctx.workspace.slotWindowToPrevScreen();
-            console.log("--------------------------");
             break;
           case "right":
-            console.log("--------------------------");
-            console.log("> Right");
-            console.log(ctx.workspace);
             ctx.workspace.slotWindowToNextScreen();
-            console.log("--------------------------");
             break;
       }
     }

--- a/src/extern/workspace.kwin.d.ts
+++ b/src/extern/workspace.kwin.d.ts
@@ -32,6 +32,11 @@ interface Workspace {
   virtualScreenGeometryChanged: QSignal;
   currentDesktopChanged: QSignal; // (desktop: IVirtualDesktop)
   cursorPosChanged: QSignal;
+  // slots
+  slotWindowToAboveScreen(): void;
+  slotWindowToBelowScreen(): void;
+  slotWindowToNextScreen(): void;
+  slotWindowToPrevScreen(): void;
   // functions
   sendClientToScreen(client: Window, output: Output): void;
   showOutline(geometry: QRect): void;


### PR DESCRIPTION
Hi! 
I want to use the keyboard to move windows across multiple monitors using the same Krohnkite shortcuts.
Recently, I contributed something similar for KZones (https://github.com/gerritdevriese/kzones/pull/147)

There is also a Krohnkite issue about this here: https://github.com/anametologin/krohnkite/issues/108

I tested my changes on two computers: on one it worked without any problems, 
but on the other, switching between two screens with very different resolutions, it behaved strangely (only moves in one direction and sometimes go to float mode).
Maybe, knowing Krohnkite’s internals,  you can help me to fix it.

Best regards, and thank you.