### PR TITLE
[Quarter Layout] Prevent Window Splits From Resetting When Closing Floating Window

### DIFF
--- a/src/layouts/quarterlayout.ts
+++ b/src/layouts/quarterlayout.ts
@@ -104,7 +104,7 @@ class QuarterLayout implements ILayout {
   ): void {
     if (CONFIG.quarterLayoutReset) {
       // Reset splits if a window was closed (i.e. tile count decreased)
-      if (tileables.length < this.prevTileCount) {
+      if (tileables.length < this.prevTileCount && this.prevTileCount <= 4) {
         this.resetSplits();
       }
       // Update the stored count for next time


### PR DESCRIPTION
As the title says, this is a very small change that prevents the Reset Layout option from activating when closing a floating window. This way, whatever adjustments you have made to window splits are maintained if you end up having to open and close an additional window.