### PR TITLE
[Quarter Layout] Per-Surface Window Splits

### DIFF
--- a/src/engine/enginecontext.ts
+++ b/src/engine/enginecontext.ts
@@ -29,9 +29,9 @@ class EngineContext {
     return this.drvctx.cursorPosition;
   }
 
-  public get surfaceParams(): string {
+  public get surfaceParams(): string[] {
     let srf = this.drvctx.currentSurface;
-    return srf.output.name, srf.activity, srf.vDesktop.name;
+    return [srf.output.name, srf.activity, srf.vDesktop.name];
   }
 
   constructor(private drvctx: IDriverContext, private engine: TilingEngine) {}

--- a/src/layouts/quarterlayout.ts
+++ b/src/layouts/quarterlayout.ts
@@ -19,20 +19,58 @@ class QuarterLayout implements ILayout {
   private lhsplit: number;
   private rhsplit: number;
   private vsplit: number;
-  private prevTileCount: number; // Track the last number of tiles
+
+  // Store splits per surface (output:activity:vDesktop) so resized windows persist per-screen/desktop
+  private splitMap: Map<string, { lhs: number; rhs: number; v: number }> = new Map();
+
+  // Helper: compute surface key from a WindowClass (basis) or EngineContext (ctx)
+  private surfaceKeyFrom(basis?: WindowClass, ctx?: EngineContext): string {
+    try {
+      if (basis && (basis as any).surface) {
+        const s = (basis as any).surface;
+        return `${s.output.name}:${s.activity}:${s.vDesktop.name}`;
+      }
+    } catch (e) { }
+    try {
+      if (ctx && (ctx as any).surfaceParams) {
+        const params = (ctx as any).surfaceParams;
+        if (Array.isArray(params) && params.length >= 3)
+          return `${params[0]}:${params[1]}:${params[2]}`;
+        return String(params);
+      }
+    } catch (e) { }
+    return "global";
+  }
+
+  // Get or create splits for a given surface key
+  private getSplitsFor(key: string) {
+    let o = this.splitMap.get(key);
+    if (!o) {
+      o = { lhs: 0.5, rhs: 0.5, v: 0.5 };
+      this.splitMap.set(key, o);
+    }
+    return o;
+  }
+
+  // Track previous tile count per-surface to avoid unintended resets when focus changes
+  private prevTileCountMap: Map<string, number> = new Map();
 
   public constructor() {
     this.lhsplit = 0.5;
     this.rhsplit = 0.5;
     this.vsplit = 0.5;
-    this.prevTileCount = 0;
+    // initialize default global splits
+    this.splitMap.set('global', { lhs: 0.5, rhs: 0.5, v: 0.5 });
   }
 
-  // Resets the splits to their default values.
-  private resetSplits(): void {
-    this.lhsplit = 0.5;
-    this.rhsplit = 0.5;
-    this.vsplit = 0.5;
+  // Resets the splits to their default values for the current surface (or globally if none provided).
+  private resetSplits(key?: string): void {
+    if (key) {
+      this.splitMap.set(key, { lhs: 0.5, rhs: 0.5, v: 0.5 });
+    } else {
+      // fallback: clear all
+      this.splitMap.clear();
+    }
   }
 
   public adjust(
@@ -42,6 +80,13 @@ class QuarterLayout implements ILayout {
     delta: RectDelta,
     gap: number
   ) {
+    // Use per-surface splits (output:activity:vDesktop) derived from the basis window
+    const skey = this.surfaceKeyFrom(basis);
+    const splits = this.getSplitsFor(skey);
+    let lhs = splits.lhs;
+    let rhs = splits.rhs;
+    let v = splits.v;
+
     if (tiles.length <= 1 || tiles.length > 4) return;
 
     const idx = tiles.indexOf(basis);
@@ -49,50 +94,69 @@ class QuarterLayout implements ILayout {
 
     /* vertical split */
     if ((idx === 0 || idx === 3) && delta.east !== 0)
-      this.vsplit = (area.width * this.vsplit + delta.east) / area.width;
+      v = (area.width * v + delta.east) / area.width;
     else if ((idx === 1 || idx === 2) && delta.west !== 0)
-      this.vsplit = (area.width * this.vsplit - delta.west) / area.width;
+      v = (area.width * v - delta.west) / area.width;
 
-    /* left-side horizontal split */
-    if (tiles.length === 4) {
+    /* horizontal split */
+    if (tiles.length === 2) {
       if (idx === 0 && delta.south !== 0)
-        this.lhsplit = (area.height * this.lhsplit + delta.south) / area.height;
-      if (idx === 3 && delta.north !== 0)
-        this.lhsplit = (area.height * this.lhsplit - delta.north) / area.height;
-    }
-
-    /* right-side horizontal split */
-    if (tiles.length >= 3) {
-      if (idx === 1 && delta.south !== 0)
-        this.rhsplit = (area.height * this.rhsplit + delta.south) / area.height;
+        lhs = (area.height * lhs + delta.south) / area.height;
+      if (idx === 1 && delta.north !== 0)
+        lhs = (area.height * lhs - delta.north) / area.height;
+    } else if (tiles.length === 3) {
+      if (idx === 0 && delta.south !== 0)
+        lhs = (area.height * lhs + delta.south) / area.height;
       if (idx === 2 && delta.north !== 0)
-        this.rhsplit = (area.height * this.rhsplit - delta.north) / area.height;
+        rhs = (area.height * rhs - delta.north) / area.height;
+    } else {
+      /* tiles.length === 4 */
+      if (idx === 0 && delta.south !== 0)
+        lhs = (area.height * lhs + delta.south) / area.height;
+      if (idx === 3 && delta.north !== 0)
+        lhs = (area.height * lhs - delta.north) / area.height;
+      if (idx === 1 && delta.south !== 0)
+        rhs = (area.height * rhs + delta.south) / area.height;
+      if (idx === 2 && delta.north !== 0)
+        rhs = (area.height * rhs - delta.north) / area.height;
     }
 
     /* clipping */
-    this.vsplit = clip(
-      this.vsplit,
+    v = clip(
+      v,
       1 - QuarterLayout.MAX_PROPORTION,
       QuarterLayout.MAX_PROPORTION
     );
-    this.lhsplit = clip(
-      this.lhsplit,
+    lhs = clip(
+      lhs,
       1 - QuarterLayout.MAX_PROPORTION,
       QuarterLayout.MAX_PROPORTION
     );
-    this.rhsplit = clip(
-      this.rhsplit,
+    rhs = clip(
+      rhs,
       1 - QuarterLayout.MAX_PROPORTION,
       QuarterLayout.MAX_PROPORTION
     );
+
+    // persist splits for this surface
+    splits.lhs = lhs;
+    splits.rhs = rhs;
+    splits.v = v;
   }
 
   public clone(): ILayout {
     const other = new QuarterLayout();
-    other.lhsplit = this.lhsplit;
-    other.rhsplit = this.rhsplit;
-    other.vsplit = this.vsplit;
-    other.prevTileCount = this.prevTileCount;
+
+    // copy per-surface split map
+    for (const [k, v] of this.splitMap) {
+      other.splitMap.set(k, { lhs: v.lhs, rhs: v.rhs, v: v.v });
+    }
+
+    // copy per-surface previous tile counts
+    for (const [k, n] of this.prevTileCountMap) {
+      other.prevTileCountMap.set(k, n);
+    }
+
     return other;
   }
 
@@ -102,34 +166,39 @@ class QuarterLayout implements ILayout {
     area: Rect,
     gap: number
   ): void {
+    // Prefer EngineContext surfaceParams for a stable surface key (avoid relying on tileables[0] order).
+    const skey = this.surfaceKeyFrom(undefined, ctx);
+    let splits = this.getSplitsFor(skey);
+
     if (CONFIG.quarterLayoutReset) {
-      // Reset splits if a window was closed (i.e. tile count decreased)
-      if (tileables.length < this.prevTileCount && this.prevTileCount <= 4) {
-        this.resetSplits();
+      // Reset splits if a window was closed (i.e. tile count decreased) for this surface only
+      const prev = this.prevTileCountMap.get(skey) ?? tileables.length;
+      if (prev > 0 && prev > tileables.length) {
+        this.resetSplits(skey);
+        // re-read splits so the newly-reset values take effect immediately
+        splits = this.getSplitsFor(skey);
       }
-      // Update the stored count for next time
-      this.prevTileCount = tileables.length;
+      this.prevTileCountMap.set(skey, tileables.length);
     }
 
-    for (let i = 0; i < 4 && i < tileables.length; i++)
-      tileables[i].state = WindowState.Tiled;
-
-    if (tileables.length > 4)
-      tileables
-        .slice(4)
-        .forEach((tile) => (tile.state = WindowState.TiledAfloat));
-
-    if (tileables.length === 1) {
-      tileables[0].geometry = area;
-      return;
-    }
+    if (tileables.length === 0) return;
 
     const gap1 = gap / 2;
     const gap2 = gap - gap1;
 
-    const leftWidth = area.width * this.vsplit;
+    const leftWidth = area.width * splits.v;
     const rightWidth = area.width - leftWidth;
     const rightX = area.x + leftWidth;
+    if (tileables.length === 1) {
+      tileables[0].geometry = new Rect(
+        area.x,
+        area.y,
+        area.width,
+        area.height
+      ).gap(0, 0, 0, 0);
+      return;
+    }
+
     if (tileables.length === 2) {
       tileables[0].geometry = new Rect(
         area.x,
@@ -146,7 +215,7 @@ class QuarterLayout implements ILayout {
       return;
     }
 
-    const rightTopHeight = area.height * this.rhsplit;
+    const rightTopHeight = area.height * splits.rhs;
     const rightBottomHeight = area.height - rightTopHeight;
     const rightBottomY = area.y + rightTopHeight;
     if (tileables.length === 3) {
@@ -171,10 +240,12 @@ class QuarterLayout implements ILayout {
       return;
     }
 
-    const leftTopHeight = area.height * this.lhsplit;
+    const leftTopHeight = area.height * splits.lhs;
     const leftBottomHeight = area.height - leftTopHeight;
     const leftBottomY = area.y + leftTopHeight;
-    if (tileables.length >= 4) {
+
+    /* 4 tiles */
+    if (tileables.length === 4) {
       tileables[0].geometry = new Rect(
         area.x,
         area.y,
@@ -206,3 +277,4 @@ class QuarterLayout implements ILayout {
     return "QuarterLayout()";
   }
 }
+


### PR DESCRIPTION
Allows tiled windows to maintain any adjustments to split ratios when changing focus across surfaces (before, the ratios were a single global value).

Had to update the surfaceParams definition to be an array of strings, but (unless I missed it when grepping) columns.ts was the only other file that called it. I did make sure to test that layout, and it seems to still be working without issue with these changes.