### PR TITLE
update 'Use separate layouts...' option descriptions (need translations)

### DIFF
--- a/res/config.ui
+++ b/res/config.ui
@@ -4865,7 +4865,7 @@
           <string>All tiled windows will have no borders. Borders will be added back if window become float.</string>
          </property>
          <property name="text">
-          <string>Use separate layouts for each Activity</string>
+          <string>Use separate layouts and window split ratios for each Activity</string>
          </property>
          <property name="checked">
           <bool>true</bool>
@@ -4878,7 +4878,7 @@
           <string>All tiled windows will have no borders. Borders will be added back if window become float.</string>
          </property>
          <property name="text">
-          <string>Use separate layouts for each Desktop</string>
+          <string>Use separate layouts and window split ratios for each Desktop</string>
          </property>
          <property name="checked">
           <bool>true</bool>

--- a/res/config.xml
+++ b/res/config.xml
@@ -507,12 +507,12 @@
     </entry>
 
     <entry name="layoutPerActivity" type="Bool">
-        <label>Use separate layouts per activity.</label>
+        <label>Use separate layouts and window split ratios per activity.</label>
         <default>true</default>
     </entry>
 
     <entry name="layoutPerDesktop" type="Bool">
-        <label>Use separate layouts per desktop.</label>
+        <label>Use separate layouts and window split ratios per desktop.</label>
         <default>true</default>
     </entry>
 


### PR DESCRIPTION
Small changes in option descriptions to clarify that they also affect window split ratios. Given that I speak neither Russian nor Mandarin Chinese, I am unable to provide accurate translations for this update but, until someone that does care enough to add them, I suppose English will suffice for now.