### PR TITLE
Improve screen boundaries for floating window movement

### DIFF
--- a/src/driver/kwindriver.ts
+++ b/src/driver/kwindriver.ts
@@ -233,7 +233,11 @@ class KWinDriver implements IDriverContext {
   public moveToScreen(window: WindowClass, direction: Direction): boolean {
     let client = (window.window as KWinWindow).window;
     let output = client.output;
-    let neighbor = this.getNeighborOutput(direction, output);
+    let neighbor = KWinDriver.getNeighborOutput(
+      this.workspace,
+      direction,
+      output,
+    );
     if (neighbor === null || neighbor === undefined) return false;
     client.minimized = true;
     this.workspace.sendClientToScreen(client, neighbor);
@@ -245,7 +249,8 @@ class KWinDriver implements IDriverContext {
     return true;
   }
 
-  private getNeighborOutput(
+  public static getNeighborOutput(
+    workspace: Workspace,
     direction: Direction,
     source: Output,
   ): Output | null {
@@ -263,7 +268,7 @@ class KWinDriver implements IDriverContext {
       }
       return false;
     }
-    for (let target of this.workspace.screens) {
+    for (let target of workspace.screens) {
       if (target === source) continue;
       let targetRect = toRect(target.geometry);
       switch (direction) {
@@ -326,7 +331,8 @@ class KWinDriver implements IDriverContext {
     let targetOutput: Output | null;
 
     while (
-      (targetOutput = this.getNeighborOutput(
+      (targetOutput = KWinDriver.getNeighborOutput(
+        this.workspace,
         oppositeDirection,
         sourceOutput,
       )) !== null
@@ -429,7 +435,8 @@ class KWinDriver implements IDriverContext {
     direction: Direction,
     winTypes: WinTypes,
   ): boolean {
-    let neighbor = this.getNeighborOutput(
+    let neighbor = KWinDriver.getNeighborOutput(
+      this.workspace,
       direction,
       this.workspace.activeScreen,
     );


### PR DESCRIPTION
Before this PR, when using the move window shortcuts on floating windows it was possible to move the window infinitely off the screen off the left and top edges (whereas the right and bottom were hard barriers). This bottom barrier also prevented moving the floating window downwards if you have outputs arranged vertically. 

This PR makes it so that all edges are hard boundaries except if there is an output/monitor in that direction. See the videos below for comparison of the behavior:

Before:
https://github.com/user-attachments/assets/8303af9d-ebe3-401a-a356-485dee7f50ab

After:
https://github.com/user-attachments/assets/8af55377-09b6-4dea-bb3c-7c9db1b269fb



 