### PR TITLE
REDO: Fix certain windows being unable to switch monitors

### DIFF
--- a/src/driver/kwindriver.ts
+++ b/src/driver/kwindriver.ts
@@ -316,25 +316,6 @@ class KWinDriver implements IDriverContext {
       return false;
     }
 
-    const clientCenterInTarget = (): boolean => {
-      try {
-        const cgeom = client.clientGeometry;
-        const tgeom = targetOutput.geometry;
-        if (!cgeom || !tgeom) return false;
-        const cw = cgeom.width ?? 0;
-        const ch = cgeom.height ?? 0;
-        const cx = cgeom.x + Math.floor(cw / 2);
-        const cy = cgeom.y + Math.floor(ch / 2);
-        const tx = tgeom.x ?? 0;
-        const ty = tgeom.y ?? 0;
-        const tw = tgeom.width ?? 0;
-        const th = tgeom.height ?? 0;
-        return cx >= tx && cx < tx + tw && cy >= ty && cy < ty + th;
-      } catch (e) {
-        return false;
-      }
-    };
-
     // Poll until timeout — then finish activation.
     const interval = 20;
     const maxWait = 100;
@@ -356,7 +337,7 @@ class KWinDriver implements IDriverContext {
     };
 
     const poll = () => {
-      if (clientCenterInTarget()) {
+      if (client.output === targetOutput){
         finishActivation();
         return;
       }


### PR DESCRIPTION
The original pull request info:
Currently, some windows (especially KDE/QT windows) have trouble being moved across monitors via Krohnkite's move-window shortcuts. I changed up the logic in moveToScreen and moveWindowsToScreen and now they seem to be moving across monitors without issue.

Before (notice the flickering which is when I try to move them between monitors):
https://github.com/user-attachments/assets/3ebaaf87-7224-4cd7-a9f3-5a84c276cc56

After:
https://github.com/user-attachments/assets/fc558d7e-02eb-4d63-94cb-cd0b41e3c10a

New:
So, after wondering for a long while why the issue stopped occurring, I realized the only thing that was different was that I temporarily changed the external display I was using. The issue stopped occurring when I switched to 1920x1080 monitor but as soon as I switched back to using my tv (4096x2160 set to 2560x1440 with 133% scale) the issue returned, so I guess it has something to do with resolution/scale weirdness with KDE. (I made sure to reboot after each install as I have been)

Additionally, the rebase I did last time somehow completely messed up the code from before, but I was able to rewrite a working fix in what is hopefully a cleaner and more agreeable manner.

If you have any questions, I will try to address them. And because I haven't said this before, thank you for making this awesome fork and keeping Krohnkite alive. 